### PR TITLE
flying mech option

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.1.05
+Date: 2025-03-18
+  Features:
+    - Added option to change the Power Armor MK4 into a flying Mech Armor, disabled by default.
+  Info:
+    - Setting is experimental for now, testing in multiplayer is likely needed.
+---------------------------------------------------------------------------------------------------
 Version: 2.1.04
 Date: 2025-03-09
   Bugfixes:

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,3 +1,5 @@
+local simulations = require("__base__.prototypes.factoriopedia-simulations")
+
 if settings.startup["pam3-nvm2"].value then
   data.raw["item"]["pamk3-nvmk2"].enabled = false
   data.raw["item"]["pamk3-nvmk2"].hidden = true
@@ -172,4 +174,35 @@ local PAM4_grid_height = settings.startup["pam3-p4gh"].value
 if settings.startup["pam3-p4xl"].value then
   data.raw["equipment-grid"]["largest-equipment-grid"].width = PAM4_grid_width
   data.raw["equipment-grid"]["largest-equipment-grid"].height = PAM4_grid_height
+end
+
+--------------------------------------------------------------------------------------------------
+if settings.startup["pam3-ma2"].value and mods["space-age"] then
+  local simulations = require("__space-age__.prototypes.factoriopedia-simulations")
+  data.raw["armor"]["pamk3-pamk4"].factoriopedia_simulation = simulations.factoriopedia_mech_armor
+  data.raw["armor"]["pamk3-pamk4"].provides_flight = true
+  data.raw["armor"]["pamk3-pamk4"].takeoff_sound = {filename = "__space-age__/sound/entity/mech-armor/mech-armor-takeoff.ogg", volume = 0.2, aggregation = {max_count = 2, remove = true}}
+  data.raw["armor"]["pamk3-pamk4"].landing_sound = {filename = "__space-age__/sound/entity/mech-armor/mech-armor-land.ogg", volume = 0.3, aggregation = {max_count = 2, remove = true, count_already_playing = true}}
+  data.raw["armor"]["pamk3-pamk4"].flight_sound = {sound={filename = "__space-age__/sound/entity/mech-armor/mech-armor-flight.ogg", volume = 0.2}}
+  for _, animation in ipairs(data.raw["character"]["character"]["animations"]) do
+  if animation.armors then
+    for _, armor in ipairs(animation.armors) do
+      if armor == "mech-armor" then
+        animation.armors[#animation.armors + 1] = "pamk3-pamk4"
+        break
+    end
+  end
+end
+end
+else
+  for _, animation in ipairs(data.raw["character"]["character"]["animations"]) do
+  if animation.armors then
+    for _, armor in ipairs(animation.armors) do
+      if armor == "power-armor-mk2" then
+        animation.armors[#animation.armors + 1] = "pamk3-pamk4"
+        break
+    end
+  end
+end
+end
 end

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
   "name":"Power Armor MK3",
   "author":"jimmy_1283",
-  "version":"2.1.04",
+  "version":"2.1.05",
   "title":"Power Armor MK3",
   "description":"Bigger, better power armors; with a bigger grid (14x14)/(20x20) and larger inventory bonus (+50)/(+60), also adds various equipment, alternatives to light and heavy armor with inventory bonus (+10)/(+20), and allows custom grid size for Spidertron.",
   "homepage":"https://forums.factorio.com/viewtopic.php?f=93&t=47506",

--- a/prototypes/item/power-armor-mk3.lua
+++ b/prototypes/item/power-armor-mk3.lua
@@ -6,7 +6,6 @@ for _, animation in ipairs(data.raw["character"]["character"]["animations"]) do
     for _, armor in ipairs(animation.armors) do
       if armor == "power-armor-mk2" then
         animation.armors[#animation.armors + 1] = "pamk3-pamk3"
-        animation.armors[#animation.armors + 1] = "pamk3-pamk4"
         break
       end
        if armor == "light-armor" then


### PR DESCRIPTION
Added option to change the Power Armor MK4 into a flying Mech Armor, disabled by default. Setting is experimental for now, testing in multiplayer is likely needed.